### PR TITLE
feat: add stability_checks skill and integrate with SWE agents

### DIFF
--- a/agents/jswe.md
+++ b/agents/jswe.md
@@ -4,7 +4,7 @@ description: (Junior SWE) Autonomous implementer that turns clear specs into wor
 model: haiku
 color: yellow
 autonomy: true
-skills: [ impl_worktree_workflow, context_scoper, diff_summarizer, pull_main, rebase ]
+skills: [ impl_worktree_workflow, context_scoper, diff_summarizer, pull_main, rebase, stability_checks ]
 hooks: [ command_router, context_trim, post_telemetry ]
 scope: [ repo, github ]
 ---
@@ -19,5 +19,5 @@ What I Do Autonomously
 
 References
 - CLAUDE.md: Agent Development Flow, Token Usage Policy.
-- Skills: impl_worktree_workflow, context_scoper, diff_summarizer.
+- Skills: impl_worktree_workflow, context_scoper, diff_summarizer, stability_checks.
 - Hooks: context_trim, post_telemetry.

--- a/agents/sswe.md
+++ b/agents/sswe.md
@@ -4,7 +4,7 @@ description: (Staff SWE) Autonomous implementer that turns clear specs into work
 model: opus
 color: purple
 autonomy: true
-skills: [ impl_worktree_workflow, context_scoper, diff_summarizer, pull_main, rebase ]
+skills: [ impl_worktree_workflow, context_scoper, diff_summarizer, pull_main, rebase, stability_checks ]
 hooks: [ command_router, context_trim, post_telemetry ]
 scope: [ repo, github ]
 ---
@@ -20,5 +20,5 @@ What I Do Autonomously
 
 References
 - CLAUDE.md: Agent Development Flow, Token Usage Policy.
-- Skills: impl_worktree_workflow, context_scoper, diff_summarizer.
+- Skills: impl_worktree_workflow, context_scoper, diff_summarizer, stability_checks.
 - Hooks: context_trim, post_telemetry.

--- a/agents/swe.md
+++ b/agents/swe.md
@@ -4,7 +4,7 @@ description: Autonomous implementer that turns clear specs into working code usi
 model: opus
 color: green
 autonomy: true
-skills: [ impl_worktree_workflow, context_scoper, diff_summarizer, pull_main, rebase ]
+skills: [ impl_worktree_workflow, context_scoper, diff_summarizer, pull_main, rebase, stability_checks ]
 hooks: [ command_router, context_trim, post_telemetry ]
 scope: [ repo, github ]
 ---
@@ -19,5 +19,5 @@ What I Do Autonomously
 
 References
 - CLAUDE.md: Agent Development Flow, Token Usage Policy.
-- Skills: impl_worktree_workflow, context_scoper, diff_summarizer.
+- Skills: impl_worktree_workflow, context_scoper, diff_summarizer, stability_checks.
 - Hooks: context_trim, post_telemetry.

--- a/commands/jswe.md
+++ b/commands/jswe.md
@@ -48,8 +48,10 @@ Follow the Agent Development Flow from CLAUDE.md (optimized for speed):
 ### 1. Preparation Phase
 - Check out main branch
 - Pull latest from remote: `git pull origin main`
-- Read PROJECT.md and look for a section called 'Stability Checks'. If found, follow those directions.
-- If not found, look for make/task/just targets with the word "sanity" and run the first one you find. If there are multiple build tools, run the first one you find for each build tool.
+- **Run stability checks (preparation phase)**: Follow the `stability_checks` skill with phase="preparation"
+  - Read PROJECT.md and look for a section called 'Stability Checks'. If found, follow those directions for the preparation phase.
+  - If not found, look for make/task/just targets with the word "sanity" and run the first one you find. If there are multiple build tools, run the first one you find for each build tool.
+  - **Exit criteria**: All stability checks must pass before proceeding to branch creation.
 
 ### 2. Branch Creation
 - Create feature branch: `git checkout -b feature/<task-name>`
@@ -94,6 +96,10 @@ Follow the Agent Development Flow from CLAUDE.md (optimized for speed):
 - Commit with clear message following repo conventions
 - Format: `<scope>: <imperative description>`
 - Example: `feat: add user authentication to API`
+- **Run stability checks (pre-push phase)**: Follow the `stability_checks` skill with phase="pre-push"
+  - Read PROJECT.md and look for a section called 'Stability Checks'. If found, follow those directions for the pre-push phase.
+  - If not found, run the same sanity targets as in preparation phase.
+  - **Exit criteria**: All stability checks must pass before pushing.
 - Push to remote: `git push -u origin <branch-name>`
 
 ### 6. PR Creation
@@ -209,6 +215,6 @@ Escalate to `/swe` if you encounter:
 - Changes affecting multiple systems or services
 
 ## Reference Documentation
-- **Skills**: `skills/impl_worktree_workflow.md` for detailed workflow, `skills/gh_pr_view.md` for PR state checking
+- **Skills**: `skills/impl_worktree_workflow.md` for detailed workflow, `skills/gh_pr_view.md` for PR state checking, `skills/stability_checks.md` for stability verification
 - **Agent**: `agents/jswe.md` for implementation patterns
 - **CLAUDE.md**: Agent Development Flow section

--- a/commands/sswe.md
+++ b/commands/sswe.md
@@ -49,8 +49,10 @@ Follow the Agent Development Flow from CLAUDE.md:
 ### 1. Preparation Phase
 - Check out main branch
 - Pull latest from remote: `git pull origin main`
-- Read PROJECT.md and look for a section called 'Stability Checks'. If found, follow those directions.
-- If not found, look for make/task/just targets with the word "sanity" and run the first one you find. If there are multiple build tools, run the first one you find for each build tool.
+- **Run stability checks (preparation phase)**: Follow the `stability_checks` skill with phase="preparation"
+  - Read PROJECT.md and look for a section called 'Stability Checks'. If found, follow those directions for the preparation phase.
+  - If not found, look for make/task/just targets with the word "sanity" and run the first one you find. If there are multiple build tools, run the first one you find for each build tool.
+  - **Exit criteria**: All stability checks must pass before proceeding to branch creation.
 
 ### 2. Branch Creation
 - Create feature branch: `git checkout -b feature/<task-name>`
@@ -100,6 +102,10 @@ Follow the Agent Development Flow from CLAUDE.md:
 - Commit with clear message following repo conventions
 - Format: `<scope>: <imperative description>`
 - Example: `feat: add user authentication to API`
+- **Run stability checks (pre-push phase)**: Follow the `stability_checks` skill with phase="pre-push"
+  - Read PROJECT.md and look for a section called 'Stability Checks'. If found, follow those directions for the pre-push phase.
+  - If not found, run the same sanity targets as in preparation phase.
+  - **Exit criteria**: All stability checks must pass before pushing.
 - Push to remote: `git push -u origin <branch-name>`
 
 ### 6. PR Creation
@@ -231,6 +237,6 @@ Use SSWE when:
 - The feature has high business impact or risk
 
 ## Reference Documentation
-- **Skills**: `skills/impl_worktree_workflow.md` for detailed workflow, `skills/gh_pr_view.md` for PR state checking, `skills/iac.md` for infrastructure as code with Terraform
+- **Skills**: `skills/impl_worktree_workflow.md` for detailed workflow, `skills/gh_pr_view.md` for PR state checking, `skills/iac.md` for infrastructure as code with Terraform, `skills/stability_checks.md` for stability verification
 - **Agent**: `agents/sswe.md` for full implementation patterns
 - **CLAUDE.md**: Agent Development Flow section

--- a/commands/swe.md
+++ b/commands/swe.md
@@ -44,8 +44,10 @@ Follow the Agent Development Flow from CLAUDE.md:
 ### 1. Preparation Phase
 - Check out main branch
 - Pull latest from remote: `git pull origin main`
-- Read PROJECT.md and look for a section called 'Stability Checks'. If found, follow those directions.
-- If not found, look for make/task/just targets with the word "sanity" and run the first one you find. If there are multiple build tools, run the first one you find for each build tool.
+- **Run stability checks (preparation phase)**: Follow the `stability_checks` skill with phase="preparation"
+  - Read PROJECT.md and look for a section called 'Stability Checks'. If found, follow those directions for the preparation phase.
+  - If not found, look for make/task/just targets with the word "sanity" and run the first one you find. If there are multiple build tools, run the first one you find for each build tool.
+  - **Exit criteria**: All stability checks must pass before proceeding to branch creation.
 
 ### 2. Branch Creation
 - Create feature branch: `git checkout -b feature/<task-name>`
@@ -89,6 +91,10 @@ Follow the Agent Development Flow from CLAUDE.md:
 - Commit with clear message following repo conventions
 - Format: `<scope>: <imperative description>`
 - Example: `feat: add user authentication to API`
+- **Run stability checks (pre-push phase)**: Follow the `stability_checks` skill with phase="pre-push"
+  - Read PROJECT.md and look for a section called 'Stability Checks'. If found, follow those directions for the pre-push phase.
+  - If not found, run the same sanity targets as in preparation phase.
+  - **Exit criteria**: All stability checks must pass before pushing.
 - Push to remote: `git push -u origin <branch-name>`
 
 ### 6. PR Creation
@@ -194,6 +200,6 @@ Follow the Agent Development Flow from CLAUDE.md:
 ```
 
 ## Reference Documentation
-- **Skills**: `skills/impl_worktree_workflow.md` for detailed workflow, `skills/gh_pr_view.md` for PR state checking, `skills/iac.md` for infrastructure as code with Terraform
+- **Skills**: `skills/impl_worktree_workflow.md` for detailed workflow, `skills/gh_pr_view.md` for PR state checking, `skills/iac.md` for infrastructure as code with Terraform, `skills/stability_checks.md` for stability verification
 - **Agent**: `agents/swe.md` for full implementation patterns
 - **CLAUDE.md**: Agent Development Flow section

--- a/skills/impl_worktree_workflow.md
+++ b/skills/impl_worktree_workflow.md
@@ -3,16 +3,19 @@ name: impl_worktree_workflow
 description: Worktree-based implementation workflow for parallel development, aligned with CLAUDE.md.
 inputs: { task: required }
 outputs: { checklist: markdown }
-dependencies: [ git, gh, project make/task targets ]
+dependencies: [ git, gh, project make/task targets, stability_checks ]
 safety: Non-destructive by default; follow CLAUDE.md guardrails.
 steps:
   - Ensure main is up-to-date (pull from origin).
+  - Run stability_checks skill (phase=preparation) to verify main is stable.
   - Create a worktree for the feature branch (e.g., `git worktree add ../repo-feature-x -b feature-x`).
   - Change to the worktree directory and implement incrementally.
   - Run tests and smoke tests via existing targets.
+  - Run stability_checks skill (phase=pre-push) before pushing.
   - Push, open DRAFT PR, iterate until green, then mark ready.
   - After merge, clean up worktree: `git worktree remove ../repo-feature-x`.
 tooling:
   - commands: bin/impl-worktree-workflow
   - git/gh; make/task; test runners
+related_skills: [ stability_checks ]
 ---

--- a/skills/stability_checks.md
+++ b/skills/stability_checks.md
@@ -1,0 +1,89 @@
+---
+name: stability_checks
+description: Verify main branch stability before development and before pushing code to remote.
+inputs: { phase: required }  # phase: "preparation" or "pre-push"
+outputs: { status: pass|fail, details: string }
+dependencies: [ git, make/task/just ]
+safety: Read-only on codebase; executes defined sanity/test targets.
+steps:
+  - Read PROJECT.md and look for a section called 'Stability Checks'.
+  - If found, follow those directions for the given phase.
+  - If not found, look for make/task/just targets with the word "sanity" and run the first one you find.
+  - Report pass/fail status with details.
+tooling:
+  - git; make/task/just; test runners
+---
+
+# Stability Checks Skill
+
+## Overview
+This skill verifies that the codebase is in a stable state. It should be run:
+1. **During preparation** - Before starting development work on main to ensure you're building on a stable foundation.
+2. **Before pushing** - After completing implementation but before pushing to remote, to catch regressions early.
+
+## Usage
+
+### Phase: Preparation
+Run at the start of any implementation workflow, after checking out and pulling main:
+```
+1. Read PROJECT.md
+2. Look for a section called 'Stability Checks'
+3. If found, follow those directions for the "preparation" phase
+4. If not found, look for make/task/just targets with the word "sanity" and run the first one you find
+5. If there are multiple build tools, run the first sanity target you find for each build tool
+```
+
+### Phase: Pre-Push
+Run after implementation and testing, but before pushing to remote:
+```
+1. Read PROJECT.md
+2. Look for a section called 'Stability Checks'
+3. If found, follow those directions for the "pre-push" phase
+4. If not found, run the same sanity targets as in preparation phase
+5. This catches any regressions introduced by your changes
+```
+
+## Example PROJECT.md Section
+
+A PROJECT.md file might define stability checks like this:
+
+```markdown
+## Stability Checks
+
+### Preparation Phase
+Run these before starting development:
+- `make lint` - Verify linting passes
+- `make test` - Run unit tests
+
+### Pre-Push Phase
+Run these before pushing code:
+- `make lint` - Verify no new linting issues
+- `make test` - Verify no test regressions
+- `make build` - Verify build succeeds
+```
+
+## Fallback Behavior
+
+If no PROJECT.md exists or no 'Stability Checks' section is found:
+1. Search for Makefile, Taskfile.yml, justfile in the repository root
+2. Look for targets containing "sanity" in their names
+3. Execute the first matching target for each build tool found
+4. Common patterns: `make sanity`, `task sanity`, `just sanity`
+
+## Safety
+
+- This skill is read-only with respect to the codebase
+- It only executes existing, defined targets
+- Failed checks should block further workflow progress
+- Success/failure status should be clearly reported
+
+## Integration with Agent Workflows
+
+Agents should invoke this skill at two points:
+1. **Step 1 (Preparation)**: After `git pull origin main`, before creating feature branch
+2. **Step 5 (Pre-Push)**: After all tests pass, before `git push`
+
+## Exit Criteria
+
+- **Pass**: All stability checks complete successfully
+- **Fail**: Any check fails; agent should investigate and fix before proceeding


### PR DESCRIPTION
## Summary
- Add new `skills/stability_checks.md` skill for verifying codebase stability at key workflow points
- Skill supports two phases: "preparation" (before development) and "pre-push" (before pushing)
- All three SWE agents (swe, jswe, sswe) now invoke stability checks at:
  - **Step 1 (Preparation)**: After pulling main, before creating feature branch
  - **Step 5 (Pre-Push)**: After tests pass, before pushing to remote

## Changes
- New file: `skills/stability_checks.md` - comprehensive skill documentation
- Updated: `agents/swe.md`, `agents/jswe.md`, `agents/sswe.md` - added stability_checks to skills list
- Updated: `commands/swe.md`, `commands/jswe.md`, `commands/sswe.md` - integrated stability checks into workflow steps
- Updated: `skills/impl_worktree_workflow.md` - referenced stability_checks as a dependency

## Test Plan
- [ ] Verify skill file follows existing skill format
- [ ] Verify agents correctly list the new skill
- [ ] Verify command workflows reference the skill at preparation and pre-push phases

## Notes
This builds on the recent addition of stability checks support in PROJECT.md. By centralizing the logic in a skill and explicitly calling it at both preparation and pre-push phases, we ensure consistent stability verification across all SWE workflows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)